### PR TITLE
feat(#42): use call to keep "this" context in click events

### DIFF
--- a/src/builder.js
+++ b/src/builder.js
@@ -127,18 +127,18 @@ class TreeBuilder {
           d.data.textClass,
           opts.callbacks.textRenderer);
       })
-      .on('click', function(d)  {
+      .on('click', function (d) {
         if (d.data.hidden) {
-          return;
+          return
         }
-        opts.callbacks.nodeClick(d.data.name, d.data.extra, d.data.id);
+        opts.callbacks.nodeClick.call(this, d.data.name, d.data.extra, d.data.id)
       })
-      .on('contextmenu', function(d)  {
+      .on('contextmenu', function (d) {
         if (d.data.hidden) {
-          return;
+          return
         }
-        d3.event.preventDefault();
-        opts.callbacks.nodeRightClick(d.data.name, d.data.extra, d.data.id);
+        d3.event.preventDefault()
+        opts.callbacks.nodeRightClick.call(this, d.data.name, d.data.extra, d.data.id)
       });
   }
 


### PR DESCRIPTION
By passing the "this" context, it is possible to query the mouse event.

**Example:**
```javascript
dTree.init(jsonData, {
	target: "#target",
	callbacks: {
		nodeClick: function (name, extra, id) {
			console.log(d3.mouse(this))
		},
		nodeRightClick: function (name, extra, id) {
			console.log(d3.mouse(this))
		},
	}
})
```