### PR TITLE
feat(#65): add custom renderer for marriages

### DIFF
--- a/src/builder.js
+++ b/src/builder.js
@@ -157,14 +157,22 @@ class TreeBuilder {
         if (d.data.hidden) {
           return;
         }
-        opts.callbacks.nodeClick(d.data.name, d.data.extra, d.data.id);
+        if (d.data.isMarriage) {
+          opts.callbacks.marriageClick(d.data.extra, d.data.id)
+        } else {
+          opts.callbacks.nodeClick(d.data.name, d.data.extra, d.data.id)
+        }
       })
       .on('contextmenu', function(d)  {
         if (d.data.hidden) {
           return;
         }
         d3.event.preventDefault();
-        opts.callbacks.nodeRightClick(d.data.name, d.data.extra, d.data.id);
+        if (d.data.isMarriage) {
+          opts.callbacks.marriageRightClick(d.data.extra, d.data.id)
+        } else {
+          opts.callbacks.nodeRightClick(d.data.name, d.data.extra, d.data.id)
+        }
       });
   }
 

--- a/src/dtree.js
+++ b/src/dtree.js
@@ -15,6 +15,8 @@ const dTree = {
       callbacks: {
         nodeClick: function(name, extra, id) {},
         nodeRightClick: function(name, extra, id) {},
+        marriageClick: function(extra, id) {},
+        marriageRightClick: function(extra, id) {},
         nodeHeightSeperation: function(nodeWidth, nodeMaxHeight) {
           return TreeBuilder._nodeHeightSeperation(nodeWidth, nodeMaxHeight);
         },

--- a/src/dtree.js
+++ b/src/dtree.js
@@ -11,6 +11,7 @@ const dTree = {
       debug: false,
       width: 600,
       height: 600,
+      hideMarriageNodes: true,
       callbacks: {
         nodeClick: function(name, extra, id) {},
         nodeRightClick: function(name, extra, id) {},
@@ -28,6 +29,12 @@ const dTree = {
         textRenderer: function(name, extra, textClass) {
           return TreeBuilder._textRenderer(name, extra, textClass);
         },
+        marriageRenderer: function (x, y, height, width, extra, id, nodeClass) {
+          return TreeBuilder._marriageRenderer(x, y, height, width, extra, id, nodeClass)
+        },
+        marriageSize: function (nodes, size) {
+          return TreeBuilder._marriageSize(nodes, size)
+        },
       },
       margin: {
         top: 0,
@@ -36,8 +43,10 @@ const dTree = {
         left: 0
       },
       nodeWidth: 100,
+      marriageNodeSize: 10,
       styles: {
         node: 'node',
+        marriageNode: 'marriageNode',
         linage: 'linage',
         marriage: 'marriage',
         text: 'nodeText'
@@ -108,15 +117,16 @@ const dTree = {
 
       // go through marriage
       _.forEach(person.marriages, function(marriage, index) {
-
         var m = {
           name: '',
           id: id++,
-          hidden: true,
+          hidden: opts.hideMarriageNodes,
           noParent: true,
           children: [],
-          extra: marriage.extra
-        };
+          isMarriage: true,
+          extra: marriage.extra,
+          class: marriage.class ? marriage.class : opts.styles.marriageNode
+        }
 
         var sp = marriage.spouse;
 


### PR DESCRIPTION
This pull request adds a custom renderer for marriage nodes.

**Example:**
```javascript
dTree.init(jsonData, {
	target: '#target',
	hideMarriageNodes: false, // turn marriage nodes on and off
	marriageNodeSize: 10, // set default node size
	callbacks: {
		marriageClick: function(extra, id) {
			/* custom code here */
		},
		marriageRightClick: function(extra, id) {
			/* custom code here */
		},
		marriageRenderer: function (x, y, height, width, extra, id, nodeClass) {
			/* custom code here */
		},
		marriageSize: function (nodes, size) {
			/* custom code here */
		},
	}
}
```
```css
/* css styles */
.marriageNode {
	background-color: deeppink;
	border-radius: 50%;
}
```

![image](https://user-images.githubusercontent.com/1511660/74000870-e0322d80-4969-11ea-8d70-24cf49e5e3e8.png)
